### PR TITLE
Add client-side speech transcription

### DIFF
--- a/companycam/companycam/components/NoteCard.tsx
+++ b/companycam/companycam/components/NoteCard.tsx
@@ -304,6 +304,12 @@ export default function NoteCard({ note, onExpand, onShare }: NoteCardProps) {
                 <span>Transcribed</span>
               </div>
             )}
+            {note.insights && note.insights.some(i => i.includes('client-side')) && (
+              <div className="flex items-center space-x-1">
+                <span>🌐</span>
+                <span>Client transcribed</span>
+              </div>
+            )}
           </div>
 
           {displayText.length > 0 && (

--- a/companycam/companycam/lib/speech-recognition-polyfill.ts
+++ b/companycam/companycam/lib/speech-recognition-polyfill.ts
@@ -1,0 +1,27 @@
+export function initializeSpeechRecognition() {
+  if (typeof window === 'undefined') return null;
+  
+  const SpeechRecognition =
+    (window as any).SpeechRecognition ||
+    (window as any).webkitSpeechRecognition ||
+    (window as any).mozSpeechRecognition ||
+    (window as any).msSpeechRecognition;
+
+  if (!SpeechRecognition) {
+    console.warn('Speech recognition not supported in this browser');
+    return null;
+  }
+
+  return SpeechRecognition;
+}
+
+export function isSpeechRecognitionSupported(): boolean {
+  return initializeSpeechRecognition() !== null;
+}
+
+export async function getSupportedLanguages(): Promise<string[]> {
+  return [
+    'en-US', 'en-GB', 'es-ES', 'es-MX', 'fr-FR', 'de-DE',
+    'it-IT', 'pt-BR', 'ru-RU', 'zh-CN', 'ja-JP', 'ko-KR'
+  ];
+}

--- a/companycam/companycam/pages/project/[id]/create.tsx
+++ b/companycam/companycam/pages/project/[id]/create.tsx
@@ -49,9 +49,11 @@ const CreateNote: NextPage<Props> = ({ project }) => {
   const handleFinish = async ({
     audio,
     images,
+    transcription,
   }: {
     audio: File;
     images: File[];
+    transcription?: string;
   }) => {
     setStatus('uploading');
     setProgress(0);
@@ -62,6 +64,11 @@ const CreateNote: NextPage<Props> = ({ project }) => {
       formData.append('projectId', project.id);
       formData.append('audio', audio);
       images.forEach((img) => formData.append('images', img));
+
+      // Include transcription if available
+      if (transcription) {
+        formData.append('clientTranscription', transcription);
+      }
 
       setProcessingStep('Uploading files...');
       const uploadResponse = await fetch('/api/upload', {

--- a/companycam/companycam/types/index.ts
+++ b/companycam/companycam/types/index.ts
@@ -23,10 +23,11 @@ export interface Note {
     color?: string;
   }
   
-  export interface MediaData {
-    audio: File;
-    images: File[];
-  }
+export interface MediaData {
+  audio: File;
+  images: File[];
+  transcription?: string;
+}
 
   export interface Stats {
     totalNotes: number;


### PR DESCRIPTION
## Summary
- enable speech recognition in `CameraRecorder`
- extend MediaData type with optional transcription
- pass transcription from client when creating a note
- update upload API to accept and prefer client transcription
- show client-side transcription indicator on notes
- add browser speech-recognition polyfill helper

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f69eafcc08320b5971fa7fc2cb235